### PR TITLE
ci: Automate version bump to v0.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ dependencies = [
 
 [[package]]
 name = "al-poseidon"
-version = "0.9.0"
+version = "0.0.1"
 dependencies = [
  "ctor",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "al-poseidon"
-version = "0.9.0"
+version = "0.0.1"
 license = "MIT-0"
 authors = ["Quantus Network Developers <hello@quantus.com>"]
 homepage = "https://quantus.com"


### PR DESCRIPTION
Automated version bump for release v0.0.1.

https://github.com/aletheia-labs/qp-poseidon-rm/actions/runs/17457516231

Triggered by workflow run: patch

Type: 