### PR TITLE
ci: Automate version bump to v0.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ dependencies = [
 
 [[package]]
 name = "al-poseidon"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "ctor",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "al-poseidon"
-version = "0.0.1"
+version = "0.0.2"
 description = "Poseidon hash implementation for Substrate/Polkadot ecosystem using plonky2 field arithmetic"
 readme = "README.md"
 license = "MIT-0"


### PR DESCRIPTION
Automated version bump for release v0.0.2.

https://github.com/aletheia-labs/qp-poseidon-rm/actions/runs/17458165740

Triggered by workflow run: patch

Type: 